### PR TITLE
Check math number property operator precedence Dart EOF generator fix

### DIFF
--- a/generators/dart/math.js
+++ b/generators/dart/math.js
@@ -172,14 +172,28 @@ Blockly.Dart['math_constant'] = function(block) {
 Blockly.Dart['math_number_property'] = function(block) {
   // Check if a number is even, odd, prime, whole, positive, or negative
   // or if it is divisible by certain number. Returns true or false.
-  const number_to_check = Blockly.Dart.valueToCode(block, 'NUMBER_TO_CHECK',
-      Blockly.Dart.ORDER_MULTIPLICATIVE);
-  if (!number_to_check) {
-    return ['false', Blockly.Dart.ORDER_ATOMIC];
-  }
-  const dropdown_property = block.getFieldValue('PROPERTY');
+  const PROPERTIES = {
+    'EVEN': [' % 2 == 0', Blockly.Dart.ORDER_MULTIPLICATIVE,
+        Blockly.Dart.ORDER_EQUALITY],
+    'ODD': [' % 2 == 1', Blockly.Dart.ORDER_MULTIPLICATIVE,
+        Blockly.Dart.ORDER_EQUALITY],
+    'WHOLE': [' % 1 == 0', Blockly.Dart.ORDER_MULTIPLICATIVE,
+        Blockly.Dart.ORDER_EQUALITY],
+    'POSITIVE': [' > 0', Blockly.Dart.ORDER_RELATIONAL,
+        Blockly.Dart.ORDER_RELATIONAL],
+    'NEGATIVE': [' < 0', Blockly.Dart.ORDER_RELATIONAL,
+        Blockly.Dart.ORDER_RELATIONAL],
+    'DIVISIBLE_BY': [null, Blockly.Dart.ORDER_MULTIPLICATIVE,
+        Blockly.Dart.ORDER_EQUALITY],
+    'PRIME': [null, Blockly.Dart.ORDER_NONE,
+        Blockly.Dart.ORDER_UNARY_POSTFIX]
+  };
+  const dropdownProperty = block.getFieldValue('PROPERTY');
+  const [suffix, inputOrder, outputOrder] = PROPERTIES[dropdownProperty];
+  const numberToCheck = Blockly.Dart.valueToCode(block, 'NUMBER_TO_CHECK',
+      inputOrder) || '0';
   let code;
-  if (dropdown_property === 'PRIME') {
+  if (dropdownProperty === 'PRIME') {
     // Prime is a special case as it is not a one-liner test.
     Blockly.Dart.definitions_['import_dart_math'] =
         'import \'dart:math\' as Math;';
@@ -204,35 +218,18 @@ Blockly.Dart['math_number_property'] = function(block) {
          '  }',
          '  return true;',
          '}']);
-    code = functionName + '(' + number_to_check + ')';
-    return [code, Blockly.Dart.ORDER_UNARY_POSTFIX];
+    code = functionName + '(' + numberToCheck + ')';
+  } else if (dropdownProperty === 'DIVISIBLE_BY') {
+    const divisor = Blockly.Dart.valueToCode(block, 'DIVISOR',
+        Blockly.Dart.ORDER_MULTIPLICATIVE) || '0';
+    if (divisor === '0') {
+      return ['false', Blockly.Dart.ORDER_ATOMIC];
+    }
+    code = numberToCheck + ' % ' + divisor + ' == 0';
+  } else {
+    code = numberToCheck + suffix;
   }
-  switch (dropdown_property) {
-    case 'EVEN':
-      code = number_to_check + ' % 2 == 0';
-      break;
-    case 'ODD':
-      code = number_to_check + ' % 2 == 1';
-      break;
-    case 'WHOLE':
-      code = number_to_check + ' % 1 == 0';
-      break;
-    case 'POSITIVE':
-      code = number_to_check + ' > 0';
-      break;
-    case 'NEGATIVE':
-      code = number_to_check + ' < 0';
-      break;
-    case 'DIVISIBLE_BY':
-      const divisor = Blockly.Dart.valueToCode(block, 'DIVISOR',
-          Blockly.Dart.ORDER_MULTIPLICATIVE);
-      if (!divisor) {
-        return ['false', Blockly.Dart.ORDER_ATOMIC];
-      }
-      code = number_to_check + ' % ' + divisor + ' == 0';
-      break;
-  }
-  return [code, Blockly.Dart.ORDER_EQUALITY];
+  return [code, outputOrder];
 };
 
 Blockly.Dart['math_change'] = function(block) {

--- a/tests/generators/golden/generated.dart
+++ b/tests/generators/golden/generated.dart
@@ -440,12 +440,16 @@ void test_number_properties() {
   unittest_assertequals(42 % 2 == 0, true, 'even');
   unittest_assertequals(42.1 % 2 == 1, false, 'odd');
   unittest_assertequals(math_isPrime(5), true, 'prime 5');
+  unittest_assertequals(math_isPrime(5 + 2), true, 'prime 5 + 2 (extra parentheses)');
   unittest_assertequals(math_isPrime(25), false, 'prime 25');
   unittest_assertequals(math_isPrime(-31.1), false, 'prime negative');
   unittest_assertequals(Math.pi % 1 == 0, false, 'whole');
   unittest_assertequals(double.infinity > 0, true, 'positive');
+  unittest_assertequals(5 + 2 > 0, true, '5 + 2 is positive (extra parentheses)');
   unittest_assertequals(-42 < 0, true, 'negative');
+  unittest_assertequals(3 + 2 < 0, false, '3 + 2 is negative (extra parentheses)');
   unittest_assertequals(42 % 2 == 0, true, 'divisible');
+  unittest_assertequals(!false, true, 'divisible by 0');
 }
 
 /// Tests the "round" block.

--- a/tests/generators/math.xml
+++ b/tests/generators/math.xml
@@ -1,4 +1,8 @@
 <xml xmlns="https://developers.google.com/blockly/xml">
+  <variables>
+    <variable id="vC|N=?5}X^+}FPTXGW`X">varToChange</variable>
+    <variable id="+!^7sr#Rwo5N.?ORCbNe">rand</variable>
+  </variables>
   <block type="unittest_main" x="13" y="13">
     <field name="SUITE_NAME">Math</field>
     <statement name="DO">
@@ -992,10 +996,10 @@
                 </value>
                 <next>
                   <block type="unittest_assertvalue" inline="false">
-                    <field name="EXPECTED">FALSE</field>
+                    <field name="EXPECTED">TRUE</field>
                     <value name="MESSAGE">
                       <block type="text">
-                        <field name="TEXT">prime 25</field>
+                        <field name="TEXT">prime 5 + 2 (extra parentheses)</field>
                       </block>
                     </value>
                     <value name="ACTUAL">
@@ -1003,8 +1007,18 @@
                         <mutation divisor_input="false"></mutation>
                         <field name="PROPERTY">PRIME</field>
                         <value name="NUMBER_TO_CHECK">
-                          <block type="math_number">
-                            <field name="NUM">25</field>
+                          <block type="math_arithmetic">
+                            <field name="OP">ADD</field>
+                            <value name="A">
+                              <block type="math_number">
+                                <field name="NUM">5</field>
+                              </block>
+                            </value>
+                            <value name="B">
+                              <block type="math_number">
+                                <field name="NUM">2</field>
+                              </block>
+                            </value>
                           </block>
                         </value>
                       </block>
@@ -1014,7 +1028,7 @@
                         <field name="EXPECTED">FALSE</field>
                         <value name="MESSAGE">
                           <block type="text">
-                            <field name="TEXT">prime negative</field>
+                            <field name="TEXT">prime 25</field>
                           </block>
                         </value>
                         <value name="ACTUAL">
@@ -1023,7 +1037,7 @@
                             <field name="PROPERTY">PRIME</field>
                             <value name="NUMBER_TO_CHECK">
                               <block type="math_number">
-                                <field name="NUM">-31.1</field>
+                                <field name="NUM">25</field>
                               </block>
                             </value>
                           </block>
@@ -1033,35 +1047,35 @@
                             <field name="EXPECTED">FALSE</field>
                             <value name="MESSAGE">
                               <block type="text">
-                                <field name="TEXT">whole</field>
+                                <field name="TEXT">prime negative</field>
                               </block>
                             </value>
                             <value name="ACTUAL">
                               <block type="math_number_property">
                                 <mutation divisor_input="false"></mutation>
-                                <field name="PROPERTY">WHOLE</field>
+                                <field name="PROPERTY">PRIME</field>
                                 <value name="NUMBER_TO_CHECK">
-                                  <block type="math_constant">
-                                    <field name="CONSTANT">PI</field>
+                                  <block type="math_number">
+                                    <field name="NUM">-31.1</field>
                                   </block>
                                 </value>
                               </block>
                             </value>
                             <next>
                               <block type="unittest_assertvalue" inline="false">
-                                <field name="EXPECTED">TRUE</field>
+                                <field name="EXPECTED">FALSE</field>
                                 <value name="MESSAGE">
                                   <block type="text">
-                                    <field name="TEXT">positive</field>
+                                    <field name="TEXT">whole</field>
                                   </block>
                                 </value>
                                 <value name="ACTUAL">
                                   <block type="math_number_property">
                                     <mutation divisor_input="false"></mutation>
-                                    <field name="PROPERTY">POSITIVE</field>
+                                    <field name="PROPERTY">WHOLE</field>
                                     <value name="NUMBER_TO_CHECK">
                                       <block type="math_constant">
-                                        <field name="CONSTANT">INFINITY</field>
+                                        <field name="CONSTANT">PI</field>
                                       </block>
                                     </value>
                                   </block>
@@ -1071,16 +1085,16 @@
                                     <field name="EXPECTED">TRUE</field>
                                     <value name="MESSAGE">
                                       <block type="text">
-                                        <field name="TEXT">negative</field>
+                                        <field name="TEXT">positive</field>
                                       </block>
                                     </value>
                                     <value name="ACTUAL">
                                       <block type="math_number_property">
                                         <mutation divisor_input="false"></mutation>
-                                        <field name="PROPERTY">NEGATIVE</field>
+                                        <field name="PROPERTY">POSITIVE</field>
                                         <value name="NUMBER_TO_CHECK">
-                                          <block type="math_number">
-                                            <field name="NUM">-42</field>
+                                          <block type="math_constant">
+                                            <field name="CONSTANT">INFINITY</field>
                                           </block>
                                         </value>
                                       </block>
@@ -1090,25 +1104,138 @@
                                         <field name="EXPECTED">TRUE</field>
                                         <value name="MESSAGE">
                                           <block type="text">
-                                            <field name="TEXT">divisible</field>
+                                            <field name="TEXT">5 + 2 is positive (extra parentheses)</field>
                                           </block>
                                         </value>
                                         <value name="ACTUAL">
                                           <block type="math_number_property">
-                                            <mutation divisor_input="true"></mutation>
-                                            <field name="PROPERTY">DIVISIBLE_BY</field>
+                                            <mutation divisor_input="false"></mutation>
+                                            <field name="PROPERTY">POSITIVE</field>
                                             <value name="NUMBER_TO_CHECK">
-                                              <block type="math_number">
-                                                <field name="NUM">42</field>
-                                              </block>
-                                            </value>
-                                            <value name="DIVISOR">
-                                              <block type="math_number">
-                                                <field name="NUM">2</field>
+                                              <block type="math_arithmetic">
+                                                <field name="OP">ADD</field>
+                                                <value name="A">
+                                                  <block type="math_number">
+                                                    <field name="NUM">5</field>
+                                                  </block>
+                                                </value>
+                                                <value name="B">
+                                                  <block type="math_number">
+                                                    <field name="NUM">2</field>
+                                                  </block>
+                                                </value>
                                               </block>
                                             </value>
                                           </block>
                                         </value>
+                                        <next>
+                                          <block type="unittest_assertvalue" inline="false">
+                                            <field name="EXPECTED">TRUE</field>
+                                            <value name="MESSAGE">
+                                              <block type="text">
+                                                <field name="TEXT">negative</field>
+                                              </block>
+                                            </value>
+                                            <value name="ACTUAL">
+                                              <block type="math_number_property">
+                                                <mutation divisor_input="false"></mutation>
+                                                <field name="PROPERTY">NEGATIVE</field>
+                                                <value name="NUMBER_TO_CHECK">
+                                                  <block type="math_number">
+                                                    <field name="NUM">-42</field>
+                                                  </block>
+                                                </value>
+                                              </block>
+                                            </value>
+                                            <next>
+                                              <block type="unittest_assertvalue" inline="false">
+                                                <field name="EXPECTED">FALSE</field>
+                                                <value name="MESSAGE">
+                                                  <block type="text">
+                                                    <field name="TEXT">3 + 2 is negative (extra parentheses)</field>
+                                                  </block>
+                                                </value>
+                                                <value name="ACTUAL">
+                                                  <block type="math_number_property">
+                                                    <mutation divisor_input="false"></mutation>
+                                                    <field name="PROPERTY">NEGATIVE</field>
+                                                    <value name="NUMBER_TO_CHECK">
+                                                      <block type="math_arithmetic">
+                                                        <field name="OP">ADD</field>
+                                                        <value name="A">
+                                                          <block type="math_number">
+                                                            <field name="NUM">3</field>
+                                                          </block>
+                                                        </value>
+                                                        <value name="B">
+                                                          <block type="math_number">
+                                                            <field name="NUM">2</field>
+                                                          </block>
+                                                        </value>
+                                                      </block>
+                                                    </value>
+                                                  </block>
+                                                </value>
+                                                <next>
+                                                  <block type="unittest_assertvalue" inline="false">
+                                                    <field name="EXPECTED">TRUE</field>
+                                                    <value name="MESSAGE">
+                                                      <block type="text">
+                                                        <field name="TEXT">divisible</field>
+                                                      </block>
+                                                    </value>
+                                                    <value name="ACTUAL">
+                                                      <block type="math_number_property">
+                                                        <mutation divisor_input="true"></mutation>
+                                                        <field name="PROPERTY">DIVISIBLE_BY</field>
+                                                        <value name="NUMBER_TO_CHECK">
+                                                          <block type="math_number">
+                                                            <field name="NUM">42</field>
+                                                          </block>
+                                                        </value>
+                                                        <value name="DIVISOR">
+                                                          <block type="math_number">
+                                                            <field name="NUM">2</field>
+                                                          </block>
+                                                        </value>
+                                                      </block>
+                                                    </value>
+                                                    <next>
+                                                      <block type="unittest_assertvalue">
+                                                        <field name="EXPECTED">TRUE</field>
+                                                        <value name="MESSAGE">
+                                                          <block type="text">
+                                                            <field name="TEXT">divisible by 0</field>
+                                                          </block>
+                                                        </value>
+                                                        <value name="ACTUAL">
+                                                          <block type="logic_negate">
+                                                            <value name="BOOL">
+                                                              <block type="math_number_property">
+                                                                <mutation divisor_input="true"></mutation>
+                                                                <field name="PROPERTY">DIVISIBLE_BY</field>
+                                                                <value name="NUMBER_TO_CHECK">
+                                                                  <block type="math_number">
+                                                                    <field name="NUM">42</field>
+                                                                  </block>
+                                                                </value>
+                                                                <value name="DIVISOR">
+                                                                  <block type="math_number">
+                                                                    <field name="NUM">0</field>
+                                                                  </block>
+                                                                </value>
+                                                              </block>
+                                                            </value>
+                                                          </block>
+                                                        </value>
+                                                      </block>
+                                                    </next>
+                                                  </block>
+                                                </next>
+                                              </block>
+                                            </next>
+                                          </block>
+                                        </next>
                                       </block>
                                     </next>
                                   </block>
@@ -1128,7 +1255,7 @@
       </block>
     </statement>
   </block>
-  <block type="procedures_defnoreturn" x="13" y="3738">
+  <block type="procedures_defnoreturn" x="48" y="3799">
     <field name="NAME">test round</field>
     <comment pinned="false" h="80" w="160">Tests the "round" block.</comment>
     <statement name="STACK">
@@ -1204,12 +1331,12 @@
       </block>
     </statement>
   </block>
-  <block type="procedures_defnoreturn" x="13" y="4038">
+  <block type="procedures_defnoreturn" x="46" y="4064">
     <field name="NAME">test change</field>
     <comment pinned="false" h="80" w="160">Tests the "change" block.</comment>
     <statement name="STACK">
       <block type="variables_set" inline="false">
-        <field name="VAR">varToChange</field>
+        <field name="VAR" id="vC|N=?5}X^+}FPTXGW`X">varToChange</field>
         <value name="VALUE">
           <block type="math_number">
             <field name="NUM">100</field>
@@ -1217,7 +1344,7 @@
         </value>
         <next>
           <block type="math_change" inline="false">
-            <field name="VAR">varToChange</field>
+            <field name="VAR" id="vC|N=?5}X^+}FPTXGW`X">varToChange</field>
             <value name="DELTA">
               <block type="math_number">
                 <field name="NUM">42</field>
@@ -1232,7 +1359,7 @@
                 </value>
                 <value name="ACTUAL">
                   <block type="variables_get">
-                    <field name="VAR">varToChange</field>
+                    <field name="VAR" id="vC|N=?5}X^+}FPTXGW`X">varToChange</field>
                   </block>
                 </value>
                 <value name="EXPECTED">
@@ -1746,7 +1873,7 @@
     <comment pinned="false" h="80" w="160">Tests the "random integer" block.</comment>
     <statement name="STACK">
       <block type="variables_set" inline="false">
-        <field name="VAR">rand</field>
+        <field name="VAR" id="+!^7sr#Rwo5N.?ORCbNe">rand</field>
         <value name="VALUE">
           <block type="math_random_int">
             <value name="FROM">
@@ -1777,7 +1904,7 @@
                     <field name="OP">GTE</field>
                     <value name="A">
                       <block type="variables_get">
-                        <field name="VAR">rand</field>
+                        <field name="VAR" id="+!^7sr#Rwo5N.?ORCbNe">rand</field>
                       </block>
                     </value>
                     <value name="B">
@@ -1792,7 +1919,7 @@
                     <field name="OP">LTE</field>
                     <value name="A">
                       <block type="variables_get">
-                        <field name="VAR">rand</field>
+                        <field name="VAR" id="+!^7sr#Rwo5N.?ORCbNe">rand</field>
                       </block>
                     </value>
                     <value name="B">
@@ -1818,7 +1945,7 @@
                     <field name="PROPERTY">WHOLE</field>
                     <value name="NUMBER_TO_CHECK">
                       <block type="variables_get">
-                        <field name="VAR">rand</field>
+                        <field name="VAR" id="+!^7sr#Rwo5N.?ORCbNe">rand</field>
                       </block>
                     </value>
                   </block>
@@ -1835,7 +1962,7 @@
     <comment pinned="false" h="80" w="160">Tests the "random fraction" block.</comment>
     <statement name="STACK">
       <block type="variables_set" inline="false">
-        <field name="VAR">rand</field>
+        <field name="VAR" id="+!^7sr#Rwo5N.?ORCbNe">rand</field>
         <value name="VALUE">
           <block type="math_random_float"></block>
         </value>
@@ -1855,7 +1982,7 @@
                     <field name="OP">GTE</field>
                     <value name="A">
                       <block type="variables_get">
-                        <field name="VAR">rand</field>
+                        <field name="VAR" id="+!^7sr#Rwo5N.?ORCbNe">rand</field>
                       </block>
                     </value>
                     <value name="B">
@@ -1870,7 +1997,7 @@
                     <field name="OP">LTE</field>
                     <value name="A">
                       <block type="variables_get">
-                        <field name="VAR">rand</field>
+                        <field name="VAR" id="+!^7sr#Rwo5N.?ORCbNe">rand</field>
                       </block>
                     </value>
                     <value name="B">
@@ -1887,9 +2014,9 @@
       </block>
     </statement>
   </block>
-  <block type="procedures_defnoreturn" y="5938" x="13">
+  <block type="procedures_defnoreturn" x="13" y="5938">
     <field name="NAME">test atan2</field>
-    <comment w="160" h="80" pinned="false">Describe this function...</comment>
+    <comment pinned="false" h="80" w="160">Describe this function...</comment>
     <statement name="STACK">
       <block type="unittest_assertequals">
         <value name="MESSAGE">


### PR DESCRIPTION
Closing, confirmed from successful Dart test that an extra new line was the problem (RichDoherty#15)
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I branched from develop
- [ ] My pull request is against develop
- [ ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
